### PR TITLE
Add getTemp

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,16 +54,16 @@ var fan = smc.getFan(0);
 // => { name: 'ExhaustZ', speed: 2176 }
 ```
 
-### `smc.getTemp(sensor, units)`
+### `smc.getTemp(sensor[, units])`
 Gets the temperature value related to a specific sensor. `sensor` is a valid SMC
-sensor name (ex: `'TC0P'`). `units` is the string `'celsius'`, `'fahrenheit'`, or
-`'kelvin'` (case insensitive). Defaults to `'celsius'`. Returns a floating point
-number that is in the units specified.
+sensor name (ex: `'TC0P'`). `units` is the string `'C'`, `'F'`, or `'K'` (case
+insensitive). Defaults to `'C'`. Returns a floating point number that is in the
+units specified.
 
 ```javascript
 var smc = require('libsmc');
 
-var fan = smc.getTemp('TC0P', 'kelvin');
+var fan = smc.getTemp('TC0P', 'K');
 // => 315.15
 ```
 

--- a/README.md
+++ b/README.md
@@ -54,5 +54,18 @@ var fan = smc.getFan(0);
 // => { name: 'ExhaustZ', speed: 2176 }
 ```
 
+### `smc.getTemp(sensor, units)`
+Gets the temperature value related to a specific sensor. `sensor` is a valid SMC
+sensor name (ex: `'TC0P'`). `units` is the string `'celsius'`, `'fahrenheit'`, or
+`'kelvin'` (case insensitive). Defaults to `'celsius'`. Returns a floating point
+number that is in the units specified.
+
+```javascript
+var smc = require('libsmc');
+
+var fan = smc.getTemp('TC0P', 'kelvin');
+// => 315.15
+```
+
 ## License
 MIT license. beltex's libsmc is [licensed separately](./deps/libsmc/LICENSE).

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ exports.getNumberOfFans = function() {
 };
 
 exports.getTemp = function(tempKey, units) {
-    if (!tempKey)
+    if (typeof tempKey !== 'string')
         throw new Error('Must pass a valid temperature key to read');
 
     var unitType = 0;
@@ -47,21 +47,19 @@ exports.getTemp = function(tempKey, units) {
 
         switch(units)
         {
-        case 'FAHRENHEIT':
+        case 'F':
             unitType = 1;
             break;
 
-        case 'KELVIN':
+        case 'K':
             unitType = 2;
             break;
 
-        case 'CELSIUS':
+        case 'C':
         default:
             unitType = 0;
         }
     }
 
-    var info = binding.GetTemp(tempKey, unitType);
-
-    return info || 0;
+    return binding.GetTemp(tempKey, unitType);
 };

--- a/index.js
+++ b/index.js
@@ -39,27 +39,8 @@ exports.getTemp = function(tempKey, units) {
     if (typeof tempKey !== 'string')
         throw new Error('Must pass a valid temperature key to read');
 
-    var unitType = 0;
+    var types = { 'C': 0, 'F': 1, 'K': 2 };
+    var selection = types[units && units.toUpperCase()] || 0;
 
-    if(units) {
-        // We unify this for checking
-        units = units.toUpperCase();
-
-        switch(units)
-        {
-        case 'F':
-            unitType = 1;
-            break;
-
-        case 'K':
-            unitType = 2;
-            break;
-
-        case 'C':
-        default:
-            unitType = 0;
-        }
-    }
-
-    return binding.GetTemp(tempKey, unitType);
+    return binding.GetTemp(tempKey, selection);
 };

--- a/index.js
+++ b/index.js
@@ -35,11 +35,33 @@ exports.getNumberOfFans = function() {
     return binding.GetFans();
 };
 
-exports.getTemp = function(tempKey) {
+exports.getTemp = function(tempKey, units) {
     if (!tempKey)
         throw new Error('Must pass a valid temperature key to read');
 
-    var info = binding.GetTemp(tempKey);
+    var unitType = 0;
+
+    if(units) {
+        // We unify this for checking
+        units = units.toUpperCase();
+
+        switch(units)
+        {
+        case 'FAHRENHEIT':
+            unitType = 1;
+            break;
+
+        case 'KELVIN':
+            unitType = 2;
+            break;
+
+        case 'CELSIUS':
+        default:
+            unitType = 0;
+        }
+    }
+
+    var info = binding.GetTemp(tempKey, unitType);
 
     return info || 0;
 };

--- a/index.js
+++ b/index.js
@@ -34,3 +34,12 @@ exports.getFan = function(number) {
 exports.getNumberOfFans = function() {
     return binding.GetFans();
 };
+
+exports.getTemp = function(tempKey) {
+    if (!tempKey)
+        throw new Error('Must pass a valid temperature key to read');
+
+    var info = binding.GetTemp(tempKey);
+
+    return info || 0;
+};

--- a/index.js
+++ b/index.js
@@ -39,6 +39,9 @@ exports.getTemp = function(tempKey, units) {
     if (typeof tempKey !== 'string')
         throw new Error('Must pass a valid temperature key to read');
 
+    if (units && typeof units !== 'string')
+        throw new Error('Must pass a valid string for units');
+
     var types = { 'C': 0, 'F': 1, 'K': 2 };
     var selection = types[units && units.toUpperCase()] || 0;
 

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -49,15 +49,6 @@ namespace libsmc {
     info.GetReturnValue().Set(status);
   }
 
-  // Checks whether the machine is under battery power. Returns a boolean.
-  NAN_METHOD(GetTemp) {
-    // Retrieve the temperature based on key
-    //TODO: Let the user pick the units.
-    double temp = get_tmp((char *)*v8::String::Utf8Value(info[0]), CELSIUS);
-
-    info.GetReturnValue().Set(temp);
-  }
-
   // Retrieves the number of fans in a machine. Returns an integer.
   NAN_METHOD(GetFans) {
     int fans = get_num_fans();
@@ -95,6 +86,37 @@ namespace libsmc {
              Nan::New(rpm));
 
     info.GetReturnValue().Set(information);
+  }
+
+  // Checks whether the machine is under battery power. Returns a boolean.
+  NAN_METHOD(GetTemp) {
+    tmp_unit_t units;
+
+    // Read the unit type in from Javascript as an integer (for our ease of use)
+    Nan::Maybe<unsigned int> maybeNumber = Nan::To<unsigned int>(info[1]);
+    unsigned int unitType = maybeNumber.FromMaybe(0);
+
+
+    // Populate our units variable
+    switch(unitType) {
+        case 1:
+            units = FAHRENHEIT;
+            break;
+
+        case 2:
+            units = KELVIN;
+            break;
+
+        case 0:
+        default:
+            units = CELSIUS;
+            break;
+    }
+
+    // Retrieve the temperature based on key
+    double temp = get_tmp((char*)*v8::String::Utf8Value(info[0]), units);
+
+    info.GetReturnValue().Set(temp);
   }
 
   // Initialize the module by exporting the methods.

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -88,7 +88,7 @@ namespace libsmc {
     info.GetReturnValue().Set(information);
   }
 
-  // Checks whether the machine is under battery power. Returns a boolean.
+  // Retrieves the temperature for the specified sensor.
   NAN_METHOD(GetTemp) {
     tmp_unit_t units;
 

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -49,6 +49,15 @@ namespace libsmc {
     info.GetReturnValue().Set(status);
   }
 
+  // Checks whether the machine is under battery power. Returns a boolean.
+  NAN_METHOD(GetTemp) {
+    // Retrieve the temperature based on key
+    //TODO: Let the user pick the units.
+    double temp = get_tmp((char *)*v8::String::Utf8Value(info[0]), CELSIUS);
+
+    info.GetReturnValue().Set(temp);
+  }
+
   // Retrieves the number of fans in a machine. Returns an integer.
   NAN_METHOD(GetFans) {
     int fans = get_num_fans();
@@ -98,6 +107,8 @@ namespace libsmc {
 
     NAN_EXPORT(exports, GetFans);
     NAN_EXPORT(exports, GetFanInformation);
+
+    NAN_EXPORT(exports, GetTemp);
   }
 
   NODE_MODULE(libsmc, Initialize)

--- a/test/disk.js
+++ b/test/disk.js
@@ -57,13 +57,21 @@ test('getFan()', function(t) {
 });
 
 test('getTemp()', function(t) {
-    t.plan(6);
+    t.plan(10);
 
     // Get the first CPU proximity value and just test that
     var info = smc.getTemp('TC0P');
 
     t.ok(typeof info === 'number');
     t.ok(info > 0);
+
+    t.throws(function(){
+        smc.getTemp(99);
+    });
+
+    t.throws(function(){
+        smc.getTemp(null);
+    });
 
     // Test units
     info = smc.getTemp('TC0P', 'F');
@@ -75,4 +83,12 @@ test('getTemp()', function(t) {
 
     t.ok(typeof info === 'number');
     t.ok(info > 200);
+
+    t.throws(function(){
+        smc.getTemp('TC0P', 99);
+    });
+
+    t.throws(function(){
+        smc.getTemp('TC0P', {});
+    });
 });

--- a/test/disk.js
+++ b/test/disk.js
@@ -57,11 +57,22 @@ test('getFan()', function(t) {
 });
 
 test('getTemp()', function(t) {
-    t.plan(2);
+    t.plan(6);
 
     // Get the first CPU proximity value and just test that
     var info = smc.getTemp('TC0P');
 
     t.ok(typeof info === 'number');
     t.ok(info > 0);
+
+    // Test units
+    info = smc.getTemp('TC0P', 'FAHRENHEIT');
+
+    t.ok(typeof info === 'number');
+    t.ok(info > 0);
+
+    info = smc.getTemp('TC0P', 'KELVIN');
+
+    t.ok(typeof info === 'number');
+    t.ok(info > 200);
 });

--- a/test/disk.js
+++ b/test/disk.js
@@ -55,3 +55,13 @@ test('getFan()', function(t) {
     t.ok(typeof info.name === 'string');
     t.ok(typeof info.speed === 'number');
 });
+
+test('getTemp()', function(t) {
+    t.plan(2);
+
+    // Get the first CPU proximity value and just test that
+    var info = smc.getTemp('TC0P');
+
+    t.ok(typeof info === 'number');
+    t.ok(info > 0);
+});

--- a/test/disk.js
+++ b/test/disk.js
@@ -66,12 +66,12 @@ test('getTemp()', function(t) {
     t.ok(info > 0);
 
     // Test units
-    info = smc.getTemp('TC0P', 'FAHRENHEIT');
+    info = smc.getTemp('TC0P', 'F');
 
     t.ok(typeof info === 'number');
     t.ok(info > 0);
 
-    info = smc.getTemp('TC0P', 'KELVIN');
+    info = smc.getTemp('TC0P', 'K');
 
     t.ok(typeof info === 'number');
     t.ok(info > 200);


### PR DESCRIPTION
Exposed the `get_tmp` call as `getTemp`. Supports units (as strings), and includes both documentation and unit tests.